### PR TITLE
Fix syntax error on directives.js

### DIFF
--- a/lstn/static/js/directives.js
+++ b/lstn/static/js/directives.js
@@ -142,7 +142,7 @@ angular.module('lstn.directives', [])
   }
 ])
 
-.directive('lstnRoomQueue', ['User', 
+.directive('lstnRoomQueue', ['User',
   function(User) {
     return {
       restrict: 'E',
@@ -259,7 +259,7 @@ angular.module('lstn.directives', [])
   }
 ])
 
-.directive('lstnTrackList', ['$parse', 
+.directive('lstnTrackList', ['$parse',
   function($parse) {
     return {
       restrict: 'E',
@@ -272,7 +272,7 @@ angular.module('lstn.directives', [])
   }
 ])
 
-.directive('lstnPlaylist', ['$timeout', 'Playlist', 
+.directive('lstnPlaylist', ['$timeout', 'Playlist',
   function($timeout, Playlist) {
     return {
       restrict: 'E',
@@ -316,7 +316,7 @@ angular.module('lstn.directives', [])
           } else {
             $scope.status.open = !$scope.status.open;
           }
-        }
+        };
       }
     };
   }


### PR DESCRIPTION
Couldn't pass grunt because jslint failed. Added semi-colon.