### PR TITLE
More grunting

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -59,7 +59,7 @@ module.exports = (grunt) ->
 
     wiredep:
       lstn:
-        src: ['lstn/templates/index.html']
+        files: ['lstn/templates/index.html']
         ignorePath: '..'
 
     useminPrepare:
@@ -77,6 +77,15 @@ module.exports = (grunt) ->
           { cwd: 'lstn/static/bower_components/fontawesome/fonts/', src:['**'], dest: 'lstn/static/dist/fonts', expand: true}
         ]
 
+    htmlmin:
+      dist:
+        files: 
+          'lstn/templates/index.html': 'lstn/templates/index.html'
+        options:
+          removeComments: true,
+          collapseWhitespace: true
+      
+
   grunt.loadNpmTasks 'grunt-contrib-jshint'
   grunt.loadNpmTasks 'grunt-contrib-copy'
   grunt.loadNpmTasks 'grunt-contrib-clean'
@@ -86,6 +95,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-watch'
   grunt.loadNpmTasks 'grunt-contrib-uglify'
   grunt.loadNpmTasks 'grunt-contrib-cssmin'
+  grunt.loadNpmTasks 'grunt-contrib-htmlmin'
   grunt.loadNpmTasks 'grunt-angular-templates'
   grunt.loadNpmTasks 'grunt-ng-constant'
   grunt.loadNpmTasks 'grunt-wiredep'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -71,7 +71,7 @@ module.exports = (grunt) ->
       html: 'lstn/templates/index.html'
 
     copy:
-      fonts:
+      dist:
         files: [
           { cwd: 'lstn/static/bower_components/bootstrap/fonts/', src:['**'], dest: 'lstn/static/dist/fonts', expand: true},
           { cwd: 'lstn/static/bower_components/fontawesome/fonts/', src:['**'], dest: 'lstn/static/dist/fonts', expand: true}
@@ -103,11 +103,12 @@ module.exports = (grunt) ->
   
   grunt.registerTask 'default', ['wiredep', 'ngconstant:development', 'jshint', 'compass', 'ngtemplates']
   grunt.registerTask 'build', [
-    'copy',
+    'copy:dist',
     'useminPrepare', 
     'concat:generated', 
     'cssmin:generated', 
     'uglify:generated', 
-    'usemin'
+    'usemin',
+    'htmlmin:dist'
   ]
   grunt.registerTask 'deploy', ['ngconstant:production', 'build']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -73,8 +73,8 @@ module.exports = (grunt) ->
     copy:
       fonts:
         files: [
-          { cwd: 'lstn/static/bower_components/bootstrap/fonts/', src:['**'], dest: 'lstn/static/dist/fonts'},
-          { cwd: 'lstn/static/bower_components/fontawesome/fonts/', src:['**'], dest: 'lstn/static/dist/fonts'}
+          { cwd: 'lstn/static/bower_components/bootstrap/fonts/', src:['**'], dest: 'lstn/static/dist/fonts', expand: true},
+          { cwd: 'lstn/static/bower_components/fontawesome/fonts/', src:['**'], dest: 'lstn/static/dist/fonts', expand: true}
         ]
 
   grunt.loadNpmTasks 'grunt-contrib-jshint'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,6 +1,7 @@
 module.exports = (grunt) ->
   jsFiles = ['lstn/static/js/**/*.js']
   grunt.initConfig
+
     ngconstant:
       options:
         space: '  '
@@ -14,6 +15,7 @@ module.exports = (grunt) ->
         options:
           dest: 'lstn/static/js/config.js'
         constants: 'config/production.json'
+
     ngtemplates:
       lstn:
         src: 'lstn/static/partials/**/*.html'
@@ -24,6 +26,7 @@ module.exports = (grunt) ->
           prefix: '/',
           url: (path) ->
             return path.substring('/lstn'.length);
+
     jshint:
       files: jsFiles
       options:
@@ -32,10 +35,12 @@ module.exports = (grunt) ->
         browser: true
         devel: true
         jquery: true
+
     jsbeautifier:
       files: jsFiles
       options:
         indent_size: 2
+
     compass:
       lstn:
         options:
@@ -43,6 +48,7 @@ module.exports = (grunt) ->
           cssDir: 'lstn/static/css'
           noLineComments: true
           force: true
+
     watch:
       ngtemplates:
         files: ['lstn/static/partials/**/*.html']
@@ -51,6 +57,11 @@ module.exports = (grunt) ->
         files: ['sass/**/*.scss']
         tasks: ['compass']
 
+    wiredep:
+      lstn:
+        src: ['lstn/templates/index.html']
+        ignorePath: '..'
+
     useminPrepare:
       html: 'lstn/templates/index.html'
       options:
@@ -58,10 +69,7 @@ module.exports = (grunt) ->
 
     usemin:
       html: 'lstn/templates/index.html'
-    wiredep:
-      lstn:
-        src: ['lstn/templates/index.html']
-        ignorePath: '..'
+
     copy:
       fonts:
         files: [
@@ -84,9 +92,13 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-wiredep'
   grunt.loadNpmTasks 'grunt-usemin'
   
-
-  grunt.registerTask 'test', ['copy']
-  grunt.registerTask 'build', ['useminPrepare', 'concat:generated', 'cssmin:generated', 'uglify:generated', 'usemin']
   grunt.registerTask 'default', ['wiredep', 'ngconstant:development', 'jshint', 'compass', 'ngtemplates']
-  grunt.registerTask 'precommit', ['jshint', 'compass', 'ngtemplates']
+  grunt.registerTask 'build', [
+    'copy',
+    'useminPrepare', 
+    'concat:generated', 
+    'cssmin:generated', 
+    'uglify:generated', 
+    'usemin'
+  ]
   grunt.registerTask 'deploy', ['ngconstant:production', 'build']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -59,7 +59,7 @@ module.exports = (grunt) ->
 
     wiredep:
       lstn:
-        files: ['lstn/templates/index.html']
+        src: ['lstn/templates/index.html']
         ignorePath: '..'
 
     useminPrepare:

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -101,7 +101,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-usemin'
   
 
-  grunt.registerTask 'build', ['useminPrepare', 'concat:generated', 'uglify:generated', 'usemin']
+  grunt.registerTask 'build', ['useminPrepare', 'concat:generated', 'cssmin:generated', 'uglify:generated', 'usemin']
   grunt.registerTask 'default', ['wiredep', 'ngconstant:development', 'jshint', 'compass', 'ngtemplates']
   grunt.registerTask 'precommit', ['jshint', 'compass', 'ngtemplates']
   grunt.registerTask 'deploy', ['ngconstant:production', 'concat', 'uglify', 'cssmin']

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -73,10 +73,9 @@ module.exports = (grunt) ->
     copy:
       fonts:
         files: [
-          { src: ['lstn/static/bower_components/bootstrap/fonts/*'], dest: 'lstn/static/dist/fonts'},
-          { src: ['lstn/static/bower_components/fontawesome/fonts/*'], dest: 'lstn/static/dist/fonts'}
+          { cwd: 'lstn/static/bower_components/bootstrap/fonts/', src:['**'], dest: 'lstn/static/dist/fonts'},
+          { cwd: 'lstn/static/bower_components/fontawesome/fonts/', src:['**'], dest: 'lstn/static/dist/fonts'}
         ]
-        
 
   grunt.loadNpmTasks 'grunt-contrib-jshint'
   grunt.loadNpmTasks 'grunt-contrib-copy'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,7 +1,5 @@
 module.exports = (grunt) ->
   jsFiles = ['lstn/static/js/**/*.js']
-  cssFiles = ['lstn/static/css/**/*.css']
-
   grunt.initConfig
     ngconstant:
       options:
@@ -26,11 +24,6 @@ module.exports = (grunt) ->
           prefix: '/',
           url: (path) ->
             return path.substring('/lstn'.length);
-    concat:
-      lstn:
-        files:
-          'lstn/static/js/lstn.js': jsFiles
-          'lstn/static/css/lstn.css': cssFiles
     jshint:
       files: jsFiles
       options:
@@ -65,29 +58,20 @@ module.exports = (grunt) ->
 
     usemin:
       html: 'lstn/templates/index.html'
-      
     wiredep:
       lstn:
         src: ['lstn/templates/index.html']
         ignorePath: '..'
-    uglify:
-      lstn:
-        options:
-          sourceMap: true
+    copy:
+      fonts:
         files: [
-          expand: true
-          cwd: 'lstn/static/js'
-          src: ['**/*.js', '!**/*.min.js', '!**/*.src.js']
-          dest: 'lstn/static/js'
+          { src: ['lstn/static/bower_components/bootstrap/fonts/*'], dest: 'lstn/static/dist/fonts'},
+          { src: ['lstn/static/bower_components/fontawesome/fonts/*'], dest: 'lstn/static/dist/fonts'}
         ]
-    cssmin:
-      lstn:
-        expand: true
-        cwd: 'lstn/static/css'
-        src: '**/*.css'
-        dest: 'lstn/static/css'
+        
 
   grunt.loadNpmTasks 'grunt-contrib-jshint'
+  grunt.loadNpmTasks 'grunt-contrib-copy'
   grunt.loadNpmTasks 'grunt-contrib-clean'
   grunt.loadNpmTasks 'grunt-contrib-concat'
   grunt.loadNpmTasks 'grunt-jsbeautifier'
@@ -101,7 +85,8 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-usemin'
   
 
+  grunt.registerTask 'test', ['copy']
   grunt.registerTask 'build', ['useminPrepare', 'concat:generated', 'cssmin:generated', 'uglify:generated', 'usemin']
   grunt.registerTask 'default', ['wiredep', 'ngconstant:development', 'jshint', 'compass', 'ngtemplates']
   grunt.registerTask 'precommit', ['jshint', 'compass', 'ngtemplates']
-  grunt.registerTask 'deploy', ['ngconstant:production', 'concat', 'uglify', 'cssmin']
+  grunt.registerTask 'deploy', ['ngconstant:production', 'build']

--- a/bower.json
+++ b/bower.json
@@ -2,10 +2,11 @@
   "name": "lstn",
   "dependencies": {
     "jquery": "~2.1.0",
+    "angular": "~1.2.16",
     "angular-cookies": "~1.2.16",
     "angular-resource": "~1.2.16",
+    "angular-sanitize": "~1.2.16",
     "angular-route": "~1.2.16",
-    "angular": "~1.2.16",
     "modernizr": "~2.7.2",
     "bootstrap": "~3.3.2",
     "fontawesome": "~4.3.0",
@@ -16,8 +17,7 @@
     "jquery-ui": "~1.11.2",
     "angular-ui-sortable": "~0.13.3",
     "moment": "~2.9.0",
-    "angular-twemoji": "~0.0.7",
-    "angular-sanitize": "~1.3.13",
+    "angular-twemoji": "~0.0.8",
     "angular-emoji-map": "~1.0.1"
   },
   "version": "0.1.0",

--- a/lstn/templates/index.html
+++ b/lstn/templates/index.html
@@ -29,15 +29,8 @@
   <meta name="theme-color" content="#ffffff">
   
   <link href='//fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
-  <!-- build:css(lstn) /static/dist/css/vendor.css -->
-  <!-- bower:css -->
-  <link rel="stylesheet" href="/static/bower_components/bootstrap/dist/css/bootstrap.css" />
-  <link rel="stylesheet" href="/static/bower_components/fontawesome/css/font-awesome.css" />
-  <!-- endbower -->
-  <!-- endbuild -->
-  <!-- build:css(lstn) /static/dist/css/lstn.css -->
-  <link rel="stylesheet" href="/static/css/app.css" />
-  <!-- endbuild -->
+  <link rel="stylesheet" href="/static/dist/css/vendor.css">
+  <link rel="stylesheet" href="/static/dist/css/lstn.css">
 
 </head>
 <body data-ng-controller="AppController">
@@ -98,40 +91,12 @@
   <div id="content" class="container" data-ng-view></div>
   <div id="apiswf"></div>
   
-  <!-- build:js(lstn) /static/dist/js/vendor.js -->
-  <!-- bower:js -->
-  <script src="/static/bower_components/modernizr/modernizr.js"></script>
-  <script src="/static/bower_components/jquery/dist/jquery.js"></script>
-  <script src="/static/bower_components/angular/angular.js"></script>
-  <script src="/static/bower_components/angular-cookies/angular-cookies.js"></script>
-  <script src="/static/bower_components/angular-resource/angular-resource.js"></script>
-  <script src="/static/bower_components/angular-route/angular-route.js"></script>
-  <script src="/static/bower_components/bootstrap/dist/js/bootstrap.js"></script>
-  <script src="/static/bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
-  <script src="/static/bower_components/swfobject/swfobject/swfobject.js"></script>
-  <script src="/static/bower_components/holderjs/holder.js"></script>
-  <script src="/static/bower_components/angular-socket-io/socket.js"></script>
-  <script src="/static/bower_components/jquery-ui/jquery-ui.js"></script>
-  <script src="/static/bower_components/angular-ui-sortable/sortable.js"></script>
-  <script src="/static/bower_components/moment/moment.js"></script>
-  <script src="/static/bower_components/angular-sanitize/angular-sanitize.js"></script>
-  <script src="/static/bower_components/angular-emoji-map/angular-emoji-map.js"></script>
-  <!-- endbower -->
-  <script src="/static/bower_components/angular-twemoji/dist/angular-twemoji.js"></script>
-  <!-- endbuild -->
+  <script src="/static/dist/js/vendor.js"></script>
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="//twemoji.maxcdn.com/twemoji.min.js"></script>
 
-  <!-- build:js(lstn) /static/dist/js/lstn.js -->
-  <script src="/static/js/config.js"></script>
-  <script src="/static/js/controllers.js"></script>
-  <script src="/static/js/services.js"></script>
-  <script src="/static/js/filters.js"></script>
-  <script src="/static/js/directives.js"></script>
-  <script src="/static/js/templates.js"></script>
-  <script src="/static/js/app.js"></script>
-  <!-- endbuild -->
+  <script src="/static/dist/js/lstn.js"></script>
 
   <div id="user" style="display: none;">%% user_json | safe %%</div>
   </body>

--- a/lstn/templates/index.html
+++ b/lstn/templates/index.html
@@ -29,7 +29,7 @@
   <meta name="theme-color" content="#ffffff">
   
   <link href='//fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
-  <!-- build:js(lstn) /static/dist/css/vendor.css -->
+  <!-- build:css(lstn) /static/dist/css/vendor.css -->
   <!-- bower:css -->
   <link rel="stylesheet" href="/static/bower_components/bootstrap/dist/css/bootstrap.css" />
   <link rel="stylesheet" href="/static/bower_components/fontawesome/css/font-awesome.css" />

--- a/lstn/templates/index.html
+++ b/lstn/templates/index.html
@@ -105,6 +105,7 @@
   <script src="/static/bower_components/angular/angular.js"></script>
   <script src="/static/bower_components/angular-cookies/angular-cookies.js"></script>
   <script src="/static/bower_components/angular-resource/angular-resource.js"></script>
+  <script src="/static/bower_components/angular-sanitize/angular-sanitize.js"></script>
   <script src="/static/bower_components/angular-route/angular-route.js"></script>
   <script src="/static/bower_components/bootstrap/dist/js/bootstrap.js"></script>
   <script src="/static/bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
@@ -114,10 +115,9 @@
   <script src="/static/bower_components/jquery-ui/jquery-ui.js"></script>
   <script src="/static/bower_components/angular-ui-sortable/sortable.js"></script>
   <script src="/static/bower_components/moment/moment.js"></script>
-  <script src="/static/bower_components/angular-sanitize/angular-sanitize.js"></script>
+  <script src="/static/bower_components/angular-twemoji/dist/angular-twemoji.min.js"></script>
   <script src="/static/bower_components/angular-emoji-map/angular-emoji-map.js"></script>
   <!-- endbower -->
-  <script src="/static/bower_components/angular-twemoji/dist/angular-twemoji.js"></script>
   <!-- endbuild -->
 
   <script src="/socket.io/socket.io.js"></script>

--- a/lstn/templates/index.html
+++ b/lstn/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en" ng-app="lstn">
 <head>
   <base href="/">
-	<meta charset="utf-8">
+  <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Listen to music with your friends">
@@ -29,8 +29,15 @@
   <meta name="theme-color" content="#ffffff">
   
   <link href='//fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" href="/static/dist/css/vendor.css">
-  <link rel="stylesheet" href="/static/dist/css/lstn.css">
+  <!-- build:js(lstn) /static/dist/css/vendor.css -->
+  <!-- bower:css -->
+  <link rel="stylesheet" href="/static/bower_components/bootstrap/dist/css/bootstrap.css" />
+  <link rel="stylesheet" href="/static/bower_components/fontawesome/css/font-awesome.css" />
+  <!-- endbower -->
+  <!-- endbuild -->
+  <!-- build:css(lstn) /static/dist/css/lstn.css -->
+  <link rel="stylesheet" href="/static/css/app.css" />
+  <!-- endbuild -->
 
 </head>
 <body data-ng-controller="AppController">
@@ -91,12 +98,40 @@
   <div id="content" class="container" data-ng-view></div>
   <div id="apiswf"></div>
   
-  <script src="/static/dist/js/vendor.js"></script>
+  <!-- build:js(lstn) /static/dist/js/vendor.js -->
+  <!-- bower:js -->
+  <script src="/static/bower_components/modernizr/modernizr.js"></script>
+  <script src="/static/bower_components/jquery/dist/jquery.js"></script>
+  <script src="/static/bower_components/angular/angular.js"></script>
+  <script src="/static/bower_components/angular-cookies/angular-cookies.js"></script>
+  <script src="/static/bower_components/angular-resource/angular-resource.js"></script>
+  <script src="/static/bower_components/angular-route/angular-route.js"></script>
+  <script src="/static/bower_components/bootstrap/dist/js/bootstrap.js"></script>
+  <script src="/static/bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
+  <script src="/static/bower_components/swfobject/swfobject/swfobject.js"></script>
+  <script src="/static/bower_components/holderjs/holder.js"></script>
+  <script src="/static/bower_components/angular-socket-io/socket.js"></script>
+  <script src="/static/bower_components/jquery-ui/jquery-ui.js"></script>
+  <script src="/static/bower_components/angular-ui-sortable/sortable.js"></script>
+  <script src="/static/bower_components/moment/moment.js"></script>
+  <script src="/static/bower_components/angular-sanitize/angular-sanitize.js"></script>
+  <script src="/static/bower_components/angular-emoji-map/angular-emoji-map.js"></script>
+  <!-- endbower -->
+  <script src="/static/bower_components/angular-twemoji/dist/angular-twemoji.js"></script>
+  <!-- endbuild -->
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="//twemoji.maxcdn.com/twemoji.min.js"></script>
 
-  <script src="/static/dist/js/lstn.js"></script>
+  <!-- build:js(lstn) /static/dist/js/lstn.js -->
+  <script src="/static/js/config.js"></script>
+  <script src="/static/js/controllers.js"></script>
+  <script src="/static/js/services.js"></script>
+  <script src="/static/js/filters.js"></script>
+  <script src="/static/js/directives.js"></script>
+  <script src="/static/js/templates.js"></script>
+  <script src="/static/js/app.js"></script>
+  <!-- endbuild -->
 
   <div id="user" style="display: none;">%% user_json | safe %%</div>
   </body>

--- a/lstn/templates/index.html
+++ b/lstn/templates/index.html
@@ -27,12 +27,18 @@
   <meta name="msapplication-TileColor" content="#2d89ef">
   <meta name="msapplication-TileImage" content="%% url_for('static', filename='/mstile-144x144.png') %%">
   <meta name="theme-color" content="#ffffff">
-
-  <link rel="stylesheet" href="%% url_for('static', filename='bower_components/bootstrap/dist/css/bootstrap.css') %%">
-  <link rel="stylesheet" href="%% url_for('static', filename='bower_components/fontawesome/css/font-awesome.css') %%">
+  
   <link href='//fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
+  <!-- build:js(lstn) /static/dist/css/vendor.css -->
+  <!-- bower:css -->
+  <link rel="stylesheet" href="/static/bower_components/bootstrap/dist/css/bootstrap.css" />
+  <link rel="stylesheet" href="/static/bower_components/fontawesome/css/font-awesome.css" />
+  <!-- endbower -->
+  <!-- endbuild -->
+  <!-- build:css(lstn) /static/dist/css/lstn.css -->
+  <link rel="stylesheet" href="/static/css/app.css" />
+  <!-- endbuild -->
 
-  <link rel="stylesheet" href="%% url_for('static', filename='css/app.css') %%" />
 </head>
 <body data-ng-controller="AppController">
   <nav class="navbar navbar-inverse navbar-fixed-top">

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-cssmin": "~0.7.0",
+    "grunt-contrib-htmlmin": "^0.4.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-uglify": "~0.3.2",
     "grunt-contrib-watch": "~0.5.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-compass": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-uglify": "~0.3.2",


### PR DESCRIPTION
### New

- CSS will now be injected and minified
- index.html will be minified
- `grunt deploy` now swaps in the production config and then runs the `build` task.

### Potential Issues
the ```copy:dist``` tasks moves font resources to ```/static/dist/fonts``` which is where the new CSS files expect them (bootstrap & fontawesome). Docker / nginx doesn't seem to think ```/static/dist/fonts``` is a directory, even though it is. Hoping this doesn't occur in production, looks like this if it does:

![screen shot 2015-02-17 at 11 04 57 am](https://cloud.githubusercontent.com/assets/2185723/6231621/e0d4e16e-b694-11e4-9c76-b6dbf655522e.png)

I'm not sure how else to fix besides switching everything to font-awesome and then use the CDN.