### PR TITLE
Better Support Responsive Design in Chat/Song Items

### DIFF
--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -420,10 +420,47 @@ body > .container > div {
   border-bottom: 4px solid #3d3d3d;
 }
 
+.track, .chat__message {
+  display: -webkit-flex;
+  display: flex;
+}
+.track .item__image, .track .item__actions, .track .item__info, .chat__message .item__image, .chat__message .item__actions, .chat__message .item__info {
+  width: auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+  margin: 0;
+}
+.track .item__image, .chat__message .item__image {
+  width: auto;
+  -webkit-flex-shrink: 1;
+  flex-shrink: 1;
+}
+.track .item__actions, .chat__message .item__actions {
+  width: auto;
+  -webkit-flex-shrink: 0;
+  flex-shrink: 0;
+  margin-right: 1em;
+}
+.track .item__info, .chat__message .item__info {
+  width: auto;
+  -webkit-flex-grow: 3;
+  flex-grow: 3;
+  margin: 0;
+}
+
+.chat__message .item__title {
+  display: -webkit-flex;
+  display: flex;
+}
+
+.chat__message__message-type {
+  -webkit-flex-grow: 1;
+  flex-grow: 1;
+}
+
 .item__image {
-  width: 13%;
+  width: 17%;
   min-height: 60px;
-  float: left;
 }
 .item__image img {
   width: 60px;
@@ -436,7 +473,6 @@ body > .container > div {
 }
 
 .item__info {
-  float: left;
   width: 75%;
   line-height: 1.23;
   padding: 3px 0 0 5px;
@@ -463,7 +499,6 @@ body > .container > div {
 }
 
 .item__actions {
-  float: right;
   margin-right: 15px;
   line-height: 50px;
 }
@@ -658,10 +693,7 @@ footer .container .text-muted {
 }
 
 .chat__timestamp {
-  display: inline-block;
-  position: absolute;
-  top: 3px;
-  right: 2px;
+  margin-right: 4px;
 }
 
 .search__box {

--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -432,8 +432,10 @@ body > .container > div {
 }
 .track .item__image, .chat__message .item__image {
   width: auto;
-  -webkit-flex-shrink: 1;
-  flex-shrink: 1;
+  -webkit-flex-basis: 60px;
+  flex-basis: 60px;
+  -webkit-flex-shrink: 0;
+  flex-shrink: 0;
 }
 .track .item__actions, .chat__message .item__actions {
   width: auto;

--- a/lstn/static/js/templates.js
+++ b/lstn/static/js/templates.js
@@ -94,20 +94,21 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
 
 
   $templateCache.put('/static/partials/directives/chat-message.html',
-    "<div id=\"message-{{ $id }}-{{ index }}-{{ message.user }}\" class=\"chat__message clearfix\">\n" +
+    "<div id=\"message-{{ $id }}-{{ index }}-{{ message.user }}\" class=\"chat__message\">\n" +
     "  <div class=\"chat__image item__image\">\n" +
     "    <img data-ng-src=\"{{ message.user.picture }}\" src=\"http://rdio3img-a.akamaihd.net/user/no-user-image-square.jpg\" />\n" +
     "  </div>\n" +
     "  <div class=\"chat__user-info item__info\">\n" +
     "    <div class=\"item__title\">\n" +
-    "      <span class=\"chat__message__user\" data-ng-bind=\"message.user.name\"></span>\n" +
-    "      <span data-ng-switch=\"message.type\">\n" +
+    "      <span class=\"chat__message__user\" data-ng-bind=\"message.user.name\"></span>&nbsp;\n" +
+    "      <span data-ng-switch=\"message.type\" class=\"chat__message__message-type\">\n" +
     "        <span class=\"chat__message--playing\" data-ng-switch-when=\"playing\">started playing</span>\n" +
     "        <span class=\"chat__message--upvoted\" data-ng-switch-when=\"upvote\">upvoted</span>\n" +
     "        <span class=\"chat__message--downvoted\" data-ng-switch-when=\"downvote\">downvoted</span>\n" +
     "        <span class=\"chat__message--skipped\" data-ng-switch-when=\"skipped\">skipped</span>\n" +
     "        <span class=\"chat__message--said\" data-ng-switch-when=\"message\">said</span>\n" +
     "      </span>\n" +
+    "      <div class=\"chat__timestamp text-muted\" data-time-from-now=\"message.created\"></div>\n" +
     "    </div>\n" +
     "    <div class=\"chat__message__message\" data-ng-if=\"message.type === 'message'\">\n" +
     "      <div class=\"wordwrap\" data-ng-bind-html=\"message.text|twemoji\"></div>\n" +
@@ -120,7 +121,6 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "        <a data-ng-href=\"http://rdio.com{{ message.track.artistUrl }}\" data-ng-bind=\"message.track.artist\" target=\"_blank\"></a>\n" +
     "      </div>\n" +
     "    </div>\n" +
-    "    <div class=\"chat__timestamp text-muted\" data-time-from-now=\"message.created\"></div>\n" +
     "  </div>\n" +
     "</div>\n"
   );
@@ -725,7 +725,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
 
 
   $templateCache.put('/static/partials/directives/track.html',
-    "<div id=\"track-{{ $id }}-{{ index }}-{{ track.key }}\" class=\"drilldown__item track clearfix\">\n" +
+    "<div id=\"track-{{ $id }}-{{ index }}-{{ track.key }}\" class=\"drilldown__item track\">\n" +
     "  <div class=\"item__image\">\n" +
     "    <img data-ng-src=\"{{ track.icon }}\" alt=\"{{ track.album }}\">\n" +
     "  </div>\n" +

--- a/lstn/static/partials/directives/chat-message.html
+++ b/lstn/static/partials/directives/chat-message.html
@@ -1,4 +1,4 @@
-<div id="message-{{ $id }}-{{ index }}-{{ message.user }}" class="chat__message clearfix">
+<div id="message-{{ $id }}-{{ index }}-{{ message.user }}" class="chat__message">
   <div class="chat__image item__image">
     <img data-ng-src="{{ message.user.picture }}" src="http://rdio3img-a.akamaihd.net/user/no-user-image-square.jpg" />
   </div>

--- a/lstn/static/partials/directives/chat-message.html
+++ b/lstn/static/partials/directives/chat-message.html
@@ -4,14 +4,15 @@
   </div>
   <div class="chat__user-info item__info">
     <div class="item__title">
-      <span class="chat__message__user" data-ng-bind="message.user.name"></span>
-      <span data-ng-switch="message.type">
+      <span class="chat__message__user" data-ng-bind="message.user.name"></span>&nbsp;
+      <span data-ng-switch="message.type" class="chat__message__message-type">
         <span class="chat__message--playing" data-ng-switch-when="playing">started playing</span>
         <span class="chat__message--upvoted" data-ng-switch-when="upvote">upvoted</span>
         <span class="chat__message--downvoted" data-ng-switch-when="downvote">downvoted</span>
         <span class="chat__message--skipped" data-ng-switch-when="skipped">skipped</span>
         <span class="chat__message--said" data-ng-switch-when="message">said</span>
       </span>
+      <div class="chat__timestamp text-muted" data-time-from-now="message.created"></div>
     </div>
     <div class="chat__message__message" data-ng-if="message.type === 'message'">
       <div class="wordwrap" data-ng-bind-html="message.text|twemoji"></div>
@@ -24,6 +25,5 @@
         <a data-ng-href="http://rdio.com{{ message.track.artistUrl }}" data-ng-bind="message.track.artist" target="_blank"></a>
       </div>
     </div>
-    <div class="chat__timestamp text-muted" data-time-from-now="message.created"></div>
   </div>
 </div>

--- a/lstn/static/partials/directives/track.html
+++ b/lstn/static/partials/directives/track.html
@@ -1,4 +1,4 @@
-<div id="track-{{ $id }}-{{ index }}-{{ track.key }}" class="drilldown__item track clearfix">
+<div id="track-{{ $id }}-{{ index }}-{{ track.key }}" class="drilldown__item track">
   <div class="item__image">
     <img data-ng-src="{{ track.icon }}" alt="{{ track.album }}">
   </div>

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -495,7 +495,8 @@ body {
 
   .item__image {
     width: auto;
-    @include flex-shrink(1);
+    @include flex-basis(60px);
+    @include flex-shrink(0);
   }
 
   .item__actions {

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -520,9 +520,8 @@ body {
 }
 
 .item__image {
-  width: 13%;
+  width: 17%;
   min-height: 60px;
-  float: left;
 
   img {
     width: 60px;

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -536,7 +536,6 @@ body {
 }
 
 .item__info {
-  float: left;
   width: 75%;
   line-height: 1.23;
 
@@ -568,7 +567,6 @@ body {
 }
 
 .item__actions {
-  float: right;
   margin-right: 15px;
   line-height: 50px;
 

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -484,6 +484,41 @@ body {
   border-bottom: 4px solid $accent-color;
 }
 
+.track, .chat__message {
+  @include display-flex;
+
+  .item__image, .item__actions, .item__info {
+    width: auto;
+    @include flex-basis(auto);
+    margin: 0;
+  }
+
+  .item__image {
+    width: auto;
+    @include flex-shrink(1);
+  }
+
+  .item__actions {
+    width: auto;
+    @include flex-shrink(0);
+    margin-right: 1em;
+  }
+
+  .item__info {
+    width: auto;
+    @include flex-grow(3);
+    margin: 0;
+  }
+}
+
+.chat__message .item__title {
+  @include display-flex;
+}
+
+.chat__message__message-type {
+  @include flex-grow(1);
+}
+
 .item__image {
   width: 13%;
   min-height: 60px;

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -4,6 +4,7 @@
 @import "compass/css3/animation";
 @import "compass/css3/transform";
 @import "compass/css3/opacity";
+@import "compass/css3/flexbox";
 @import "variables";
 
 html, body {

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -737,10 +737,7 @@ footer {
 }
 
 .chat__timestamp {
-  display: inline-block;
-  position: absolute;
-  top: 3px;
-  right: 2px;
+  margin-right: 4px;
 }
 
 .search__box {


### PR DESCRIPTION
Bro, do you even flex? Fixes #177 

Fullsize
-
<img src="https://s3.amazonaws.com/f.cl.ly/items/1G3w0U0N361Y3c3F302B/Screen%20Shot%202015-02-23%20at%209.21.40%20PM.png"/>

Small As Chrome Can Go
-
<img src="https://s3.amazonaws.com/f.cl.ly/items/412N1n2X3V3X2n1I3I41/Screen%20Shot%202015-02-23%20at%209.39.43%20PM.png" />

There's still some jank around with width of the chat column, but that seems unrelated to #177, and it looks like the column is getting forced to 400px. There's also a *little* bit of jank in the chat "title" at middleground sizes, where there's not a comfortable space between the "Brian Graham started playing" and the timestamp, but it's better than text shifting all around the place.