### PR TITLE
Polishing in prep for some kind of launch (Fixes #134, #139, and #153)

### DIFF
--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -251,7 +251,6 @@ body > .container > div {
 .playing__info--stopped {
   background: #3d3d3d;
   min-height: 180px;
-  line-height: 180px;
   text-align: center;
   color: #fff;
   font-size: 1.7rem;
@@ -260,6 +259,15 @@ body > .container > div {
   font-size: 8rem;
   line-height: 180px;
   color: #5cb85c;
+  cursor: pointer;
+}
+
+.playing__info--ready {
+  line-height: 180px;
+}
+
+.playing__info--waiting {
+  line-height: 180px;
 }
 
 .playing__info--playing {

--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -535,6 +535,12 @@ body > .container > div {
   text-overflow: ellipsis;
   overflow: hidden;
 }
+.item__info .item__title.item__title--single {
+  padding-top: 17px;
+}
+.item__info .item__title.item__title--couple {
+  padding-top: 8px;
+}
 .item__info .item__artist {
   width: 100%;
   font-size: 14px;

--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -120,7 +120,7 @@ body > .container > div {
   font-size: 1.4em;
 }
 .navbar-inverse .navbar-text {
-  margin-top: 0.95em;
+  margin-top: 1.05em;
 }
 .navbar-inverse .navbar-nav.navbar-right {
   margin: 0;
@@ -154,8 +154,8 @@ body > .container > div {
   margin-right: 5px;
 }
 .navbar-right .navbar__divider {
-  margin-left: 5px;
-  margin-right: 5px;
+  margin-left: -10px;
+  margin-right: -10px;
 }
 .navbar-right .navbar__room a {
   font-weight: bold;

--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -89,7 +89,6 @@ body {
 }
 body > .container {
   height: 100%;
-  margin-bottom: 10px;
 }
 body > .container > div {
   height: 80%;

--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -89,9 +89,10 @@ body {
 }
 body > .container {
   height: 100%;
+  margin-bottom: 10px;
 }
 body > .container > div {
-  height: 85%;
+  height: 80%;
   margin-top: 15px;
 }
 
@@ -125,15 +126,10 @@ body > .container > div {
 .navbar-inverse .navbar-nav.navbar-right {
   margin: 0;
 }
-.navbar-inverse .navbar-nav > li > a.navbar__name {
-  color: #FFFFFF;
-  padding-left: 10px;
-}
-.navbar-inverse .navbar-nav > .open > a {
-  background-color: #333;
-}
-.navbar-inverse .navbar-nav > .open > a:focus, .navbar-inverse .navbar-nav > .open > a:hover {
-  background-color: #333;
+.navbar-inverse .navbar-nav.navbar-right .divider {
+  line-height: 70px;
+  width: 1px;
+  border-left: 1px solid #333;
 }
 
 .navbar-logo {
@@ -370,7 +366,7 @@ body > .container > div {
 }
 
 .queue__tabs {
-  height: 90%;
+  height: 100%;
   min-height: 400px;
   background-color: #3d3d3d;
 }
@@ -403,7 +399,7 @@ body > .container > div {
 }
 
 .tab-content {
-  height: 95%;
+  height: 100%;
 }
 .tab-content .tab-pane {
   height: 100%;
@@ -685,7 +681,7 @@ footer .container .text-muted {
   }
 }
 .room-activity {
-  height: 95%;
+  height: 100%;
   background-color: #3d3d3d;
 }
 .room-activity .form-control {
@@ -788,16 +784,19 @@ footer .container .text-muted {
   text-transform: uppercase;
   text-decoration: none;
 }
+.carousel__back .carousel__refresh {
+  padding-right: 15px;
+  color: white;
+}
+.carousel__back .carousel__refresh .fa {
+  font-size: 1.25em;
+}
 
 /* sm */
 @media (min-width: 768px) {
   div.room > div.room__middle {
     padding-left: 15px;
     padding-right: 15px;
-  }
-
-  div.queue__tabs {
-    height: 100%;
   }
 }
 /* md */

--- a/lstn/static/js/directives.js
+++ b/lstn/static/js/directives.js
@@ -392,7 +392,7 @@ angular.module('lstn.directives', ['sc.twemoji'])
             }
 
             CurrentUser.updateQueue({
-              queue: $scope.queue
+              queue: $scope.queue.tracks
             }, function(response) {
               if (!response || !response.success) {
                 console.log('CurrentUser.updateQueue', response);
@@ -422,6 +422,25 @@ angular.module('lstn.directives', ['sc.twemoji'])
   }
 ])
 
+.directive('lstnDrilldownBack', [
+  function() {
+    return {
+      restrict: 'E',
+      replace: true,
+      scope: {
+        text: '=',
+        tooltipText: '=',
+        clickHandler: '=',
+        refreshHandler: '=',
+        refreshText: '=',
+        loading: '=',
+        loadingText: '='
+      },
+      templateUrl: '/static/partials/directives/drilldown-back.html'
+    };
+  }
+])
+
 .directive('lstnMusicCategories', ['$timeout', 'Alert', 'CurrentUser', 'Playlist', 'Station',
   function($timeout, Alert, CurrentUser, Playlist, Station) {
     return {
@@ -440,7 +459,7 @@ angular.module('lstn.directives', ['sc.twemoji'])
         // Categories
         $scope.categories = [{
           name: 'Playlists',
-          type: 'playlists',
+          type: 'playlists'
         },{
           name: 'Stations',
           type: 'stations'
@@ -544,6 +563,18 @@ angular.module('lstn.directives', ['sc.twemoji'])
           $scope.currentPlaylistType = null;
         };
 
+        $scope.refreshPlaylistType = function() {
+          if (!$scope.currentPlaylistType) {
+            return;
+          }
+
+          if ($scope.currentPlaylistType.loadingPlaylists) {
+            return;
+          }
+
+          $scope.loadPlaylists($scope.currentPlaylistType);
+        };
+
         // Playlist Tracks
         $scope.currentPlaylist = null;
         $scope.tracks = [];
@@ -562,6 +593,7 @@ angular.module('lstn.directives', ['sc.twemoji'])
 
             $scope.tracks = response.tracks;
             $scope.currentPlaylist = playlist;
+            $scope.currentPlaylist.length = $scope.tracks.length;
 
             $timeout(function() {
               playlist.loadingTracks = false;
@@ -588,6 +620,18 @@ angular.module('lstn.directives', ['sc.twemoji'])
           $scope.currentPlaylist = null;
         };
 
+        $scope.refreshPlaylist = function() {
+          if (!$scope.currentPlaylist) {
+            return;
+          }
+
+          if ($scope.currentPlaylist.loadingTracks) {
+            return;
+          }
+
+          $scope.loadPlaylistTracks($scope.currentPlaylist);
+        };
+
         // Station Types
         $scope.stationTypes = [{
           name: 'Your Stations',
@@ -598,18 +642,6 @@ angular.module('lstn.directives', ['sc.twemoji'])
         },{
           name: 'Recent Stations',
           key: 'recent'
-        },{
-          name: 'Genre',
-          key: 'genre'
-        },{
-          name: 'Top Stations',
-          key: 'top'
-        },{
-          name: 'New Releases',
-          key: 'new'
-        },{
-          name: 'Spotlight',
-          key: 'spotlight'
         }];
 
         $scope.loadStationTypes = function(category) {
@@ -668,6 +700,18 @@ angular.module('lstn.directives', ['sc.twemoji'])
           $scope.currentStationType = null;
         };
 
+        $scope.refreshStationType = function() {
+          if (!$scope.currentStationType) {
+            return;
+          }
+
+          if ($scope.currentStationType.loadingStations) {
+            return;
+          }
+
+          $scope.loadStations($scope.currentStationType);
+        };
+
         // Station Tracks
         $scope.currentStation = null;
         $scope.tracks = [];
@@ -686,6 +730,7 @@ angular.module('lstn.directives', ['sc.twemoji'])
 
             $scope.tracks = response.tracks;
             $scope.currentStation = station;
+            $scope.currentStation.length = $scope.tracks.length;
 
             $timeout(function() {
               station.loadingTracks = false;
@@ -710,6 +755,18 @@ angular.module('lstn.directives', ['sc.twemoji'])
           controller.select(prevSlide, 'prev');
 
           $scope.currentStation = null;
+        };
+
+        $scope.refreshStation = function() {
+          if (!$scope.currentStation) {
+            return;
+          }
+
+          if ($scope.currentStation.loadingTracks) {
+            return;
+          }
+
+          $scope.loadStationTracks($scope.currentStation);
         };
       }
     };

--- a/lstn/static/js/templates.js
+++ b/lstn/static/js/templates.js
@@ -65,7 +65,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
 
 
   $templateCache.put('/static/partials/directives/category.html',
-    "<div id=\"category{{ $id }}\" class=\"drilldown__item category clearfix\">\n" +
+    "<div id=\"category{{ $id }}\" class=\"drilldown__item category\">\n" +
     "  <div class=\"item__image\">\n" +
     "    <i class=\"fa fa-fw fa-music fa-3x\"></i>\n" +
     "  </div>\n" +
@@ -126,6 +126,27 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
   );
 
 
+  $templateCache.put('/static/partials/directives/drilldown-back.html',
+    "<div class=\"carousel__back text-left\">\n" +
+    "  <a data-ng-click=\"clickHandler()\">\n" +
+    "    <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"text\" data-tooltip=\"{{ tooltipText }}\" data-tooltip-placement=\"right\"></span>\n" +
+    "  </a>\n" +
+    "  <a class=\"carousel__refresh pull-right\" data-ng-click=\"refreshHandler()\">\n" +
+    "    <i\n" +
+    "      class=\"fa fa-fw fa-refresh\"\n" +
+    "      data-ng-show=\"!loading\"\n" +
+    "      data-tooltip=\"{{ refreshText }}\"\n" +
+    "      data-tooltip-placement=\"left\"></i>\n" +
+    "    <i\n" +
+    "      class=\"fa fa-fw fa-circle-o-notch fa-spin\"\n" +
+    "      data-ng-show=\"loading\"\n" +
+    "      data-tooltip=\"{{ loadingText }}\"\n" +
+    "      data-tooltip-placement=\"left\"></i>\n" +
+    "  </a>\n" +
+    "</div>\n"
+  );
+
+
   $templateCache.put('/static/partials/directives/emoticon-list.html',
     "<ul class=\"list-group emoticon-list\">\n" +
     "  <li data-mentio-menu-item=\"emoticon\" data-ng-repeat=\"emoticon in items\" class=\"list-group-item\">\n" +
@@ -172,11 +193,14 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "    </slide>\n" +
     "\n" +
     "    <slide id=\"playlists\">\n" +
-    "      <div class=\"carousel__back text-left\">\n" +
-    "        <a data-ng-click=\"closePlaylistType()\">\n" +
-    "          <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentPlaylistType.name\"></span>\n" +
-    "        </a>\n" +
-    "      </div>\n" +
+    "      <lstn-drilldown-back\n" +
+    "        data-text=\"currentPlaylistType.name\"\n" +
+    "        data-tooltip-text=\"'Back to Categories'\"\n" +
+    "        data-click-handler=\"closePlaylistType\"\n" +
+    "        data-refresh-handler=\"refreshPlaylistType\"\n" +
+    "        data-refresh-text=\"'Refresh Playlists'\"\n" +
+    "        data-loading=\"currentPlaylistType.loadingPlaylists\"\n" +
+    "        data-loading-text=\"'Refreshing Playlists'\"></lstn-drilldown-back>\n" +
     "      <ul class=\"playlists drilldown__list text-left\">\n" +
     "        <li data-ng-repeat=\"item in playlists\">\n" +
     "          <lstn-playlist\n" +
@@ -189,11 +213,14 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "    </slide>\n" +
     "\n" +
     "    <slide id=\"playlist_tracks\">\n" +
-    "      <div class=\"carousel__back text-left\">\n" +
-    "        <a data-ng-click=\"closePlaylist()\">\n" +
-    "          <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentPlaylist.name\"></span>\n" +
-    "        </a>\n" +
-    "      </div>\n" +
+    "      <lstn-drilldown-back\n" +
+    "        data-text=\"currentPlaylist.name\"\n" +
+    "        data-tooltip-text=\"'Back to Playlists'\"\n" +
+    "        data-click-handler=\"closePlaylist\"\n" +
+    "        data-refresh-handler=\"refreshPlaylist\"\n" +
+    "        data-refresh-text=\"'Refresh Playlist'\"\n" +
+    "        data-loading=\"currentPlaylist.loadingTracks\"\n" +
+    "        data-loading-text=\"'Refreshing Playlist'\"></lstn-drilldown-back>\n" +
     "      <ul class=\"tracks drilldown__list text-left\">\n" +
     "        <li data-ng-repeat=\"item in tracks\">\n" +
     "          <lstn-track\n" +
@@ -220,11 +247,14 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "    </slide>\n" +
     "\n" +
     "    <slide id=\"stations\">\n" +
-    "      <div class=\"carousel__back text-left\">\n" +
-    "        <a data-ng-click=\"closeStationType()\">\n" +
-    "          <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentStationType.name\"></span>\n" +
-    "        </a>\n" +
-    "      </div>\n" +
+    "      <lstn-drilldown-back\n" +
+    "        data-text=\"currentStationType.name\"\n" +
+    "        data-tooltip-text=\"'Back to Categories'\"\n" +
+    "        data-click-handler=\"closeStationType\"\n" +
+    "        data-refresh-handler=\"refreshStationType\"\n" +
+    "        data-refresh-text=\"'Refresh Stations'\"\n" +
+    "        data-loading=\"currentStationType.loadingStations\"\n" +
+    "        data-loading-text=\"'Refreshing Stations'\"></lstn-drilldown-back>\n" +
     "      <ul class=\"stations drilldown__list text-left\">\n" +
     "        <li data-ng-repeat=\"item in stations\">\n" +
     "          <lstn-playlist\n" +
@@ -237,11 +267,14 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "    </slide>\n" +
     "\n" +
     "    <slide id=\"station_tracks\">\n" +
-    "      <div class=\"carousel__back text-left\">\n" +
-    "        <a data-ng-click=\"closeStation()\">\n" +
-    "          <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentStation.name\"></span>\n" +
-    "        </a>\n" +
-    "      </div>\n" +
+    "      <lstn-drilldown-back\n" +
+    "        data-text=\"currentStation.name\"\n" +
+    "        data-tooltip-text=\"'Back to Stations'\"\n" +
+    "        data-click-handler=\"closeStation\"\n" +
+    "        data-refresh-handler=\"refreshStation\"\n" +
+    "        data-refresh-text=\"'Refresh Station'\"\n" +
+    "        data-loading=\"currentStation.loadingTracks\"\n" +
+    "        data-loading-text=\"'Refreshing Station'\"></lstn-drilldown-back>\n" +
     "      <ul class=\"tracks drilldown__list text-left\">\n" +
     "        <li data-ng-repeat=\"item in tracks\">\n" +
     "          <lstn-track\n" +
@@ -373,7 +406,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
 
 
   $templateCache.put('/static/partials/directives/playlist-type.html',
-    "<div id=\"playlist-type{{ $id }}\" class=\"drilldown__item playlist-type clearfix\">\n" +
+    "<div id=\"playlist-type{{ $id }}\" class=\"drilldown__item playlist-type\">\n" +
     "  <div class=\"item__image\">\n" +
     "    <i class=\"fa fa-fw fa-music fa-3x\"></i>\n" +
     "  </div>\n" +

--- a/lstn/static/js/templates.js
+++ b/lstn/static/js/templates.js
@@ -626,7 +626,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "      <li class=\"roster__item--controller\"\n" +
     "        data-ng-show=\"roster && roster.controllersCount > 0\" data-ng-repeat=\"user_id in roster.controllerOrder\">\n" +
     "        <a data-ng-href=\"http://www.rdio.com{{ roster.controllers[user_id].profile }}\" target=\"_blank\"\n" +
-    "          tooltip=\"{{ roster.controllers[user_id].name }}\" data-tooltip-placement=\"bottom\">\n" +
+    "          tooltip=\"{{ roster.controllers[user_id].name }} ({{ roster.controllers[user_id].points }})\" data-tooltip-placement=\"bottom\">\n" +
     "          <img data-ng-src=\"{{ roster.controllers[user_id].picture }}\" class=\"avatar xs\"\n" +
     "            data-ng-class=\"{upvoted: playing.upvotes[user_id], downvoted: playing.downvotes[user_id]}\"\n" +
     "            alt=\"{{ roster.controllers[user_id].name }}\" />\n" +
@@ -646,7 +646,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "      <a class=\"roster__user\"\n" +
     "        data-ng-href=\"http://www.rdio.com{{ user.profile }}\"\n" +
     "        target=\"_blank\"\n" +
-    "        tooltip=\"{{ user.name }}\" data-tooltip-placement=\"bottom\">\n" +
+    "        tooltip=\"{{ user.name }} ({{ user.points }})\" data-tooltip-placement=\"bottom\">\n" +
     "        <img data-ng-src=\"{{ user.picture }}\"\n" +
     "        data-ng-class=\"{upvoted: playing.upvotes[user_id], downvoted: playing.downvotes[user_id]}\"\n" +
     "        class=\"avatar xs\" alt=\"{{ user.name }}\" />\n" +

--- a/lstn/static/js/templates.js
+++ b/lstn/static/js/templates.js
@@ -131,7 +131,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "  <a data-ng-click=\"clickHandler()\">\n" +
     "    <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"text\" data-tooltip=\"{{ tooltipText }}\" data-tooltip-placement=\"right\"></span>\n" +
     "  </a>\n" +
-    "  <a class=\"carousel__refresh pull-right\" data-ng-click=\"refreshHandler()\">\n" +
+    "  <a class=\"carousel__refresh pull-right\" data-ng-click=\"refreshHandler()\" data-ng-show=\"refreshHandler\">\n" +
     "    <i\n" +
     "      class=\"fa fa-fw fa-refresh\"\n" +
     "      data-ng-show=\"!loading\"\n" +
@@ -178,11 +178,10 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "    </slide>\n" +
     "\n" +
     "    <slide id=\"playlist_types\">\n" +
-    "      <div class=\"carousel__back text-left\">\n" +
-    "        <a data-ng-click=\"closeCategory()\">\n" +
-    "          <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentCategory.name\"></span>\n" +
-    "        </a>\n" +
-    "      </div>\n" +
+    "      <lstn-drilldown-back\n" +
+    "        data-text=\"currentCategory.name\"\n" +
+    "        data-tooltip-text=\"'Back to Categories'\"\n" +
+    "        data-click-handler=\"closeCategory\"></lstn-drilldown-back>\n" +
     "      <ul class=\"playlist-types playlist-types--full playlist-type__list drilldown__list text-left\">\n" +
     "        <li data-ng-repeat=\"item in playlistTypes\">\n" +
     "          <lstn-playlist-type\n" +
@@ -195,7 +194,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "    <slide id=\"playlists\">\n" +
     "      <lstn-drilldown-back\n" +
     "        data-text=\"currentPlaylistType.name\"\n" +
-    "        data-tooltip-text=\"'Back to Categories'\"\n" +
+    "        data-tooltip-text=\"'Back to Playlist Types'\"\n" +
     "        data-click-handler=\"closePlaylistType\"\n" +
     "        data-refresh-handler=\"refreshPlaylistType\"\n" +
     "        data-refresh-text=\"'Refresh Playlists'\"\n" +
@@ -232,11 +231,10 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "    </slide>\n" +
     "\n" +
     "    <slide id=\"station_types\">\n" +
-    "      <div class=\"carousel__back text-left\">\n" +
-    "        <a data-ng-click=\"closeCategory()\">\n" +
-    "          <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentCategory.name\"></span>\n" +
-    "        </a>\n" +
-    "      </div>\n" +
+    "      <lstn-drilldown-back\n" +
+    "        data-text=\"currentCategory.name\"\n" +
+    "        data-tooltip-text=\"'Back to Categories'\"\n" +
+    "        data-click-handler=\"closeCategory\"></lstn-drilldown-back>\n" +
     "      <ul class=\"station-types station-types--full station-type__list drilldown__list text-left\">\n" +
     "        <li data-ng-repeat=\"item in stationTypes\">\n" +
     "          <lstn-station-type\n" +
@@ -249,7 +247,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "    <slide id=\"stations\">\n" +
     "      <lstn-drilldown-back\n" +
     "        data-text=\"currentStationType.name\"\n" +
-    "        data-tooltip-text=\"'Back to Categories'\"\n" +
+    "        data-tooltip-text=\"'Back to Station Types'\"\n" +
     "        data-click-handler=\"closeStationType\"\n" +
     "        data-refresh-handler=\"refreshStationType\"\n" +
     "        data-refresh-text=\"'Refresh Stations'\"\n" +

--- a/lstn/static/js/templates.js
+++ b/lstn/static/js/templates.js
@@ -71,7 +71,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "  </div>\n" +
     "  <div class=\"item__info\">\n" +
     "    <div\n" +
-    "      class=\"item__title\"\n" +
+    "      class=\"item__title item__title--single\"\n" +
     "      data-ng-bind=\"category.name\"></div>\n" +
     "  </div>\n" +
     "  <div class=\"item__actions\">\n" +
@@ -410,7 +410,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "  </div>\n" +
     "  <div class=\"item__info\">\n" +
     "    <div\n" +
-    "      class=\"item__title\"\n" +
+    "      class=\"item__title item__title--single\"\n" +
     "      data-ng-bind=\"playlistType.name\"></div>\n" +
     "  </div>\n" +
     "  <div class=\"item__actions\">\n" +
@@ -439,7 +439,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "  </div>\n" +
     "  <div class=\"item__info\">\n" +
     "    <div\n" +
-    "      class=\"item__title\"\n" +
+    "      class=\"item__title item__title--couple\"\n" +
     "      data-ng-bind=\"playlist.name\"></div>\n" +
     "    <div class=\"item__count\" data-ng-pluralize count=\"playlist.length\" when=\"{'one': '{} track', 'other': '{} tracks'}\"></div>\n" +
     "  </div>\n" +
@@ -706,7 +706,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "  </div>\n" +
     "  <div class=\"item__info\">\n" +
     "    <div\n" +
-    "      class=\"item__title\"\n" +
+    "      class=\"item__title item__title--single\"\n" +
     "      data-ng-bind=\"stationType.name\"></div>\n" +
     "  </div>\n" +
     "  <div class=\"item__actions\">\n" +
@@ -735,7 +735,7 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "  </div>\n" +
     "  <div class=\"item__info\">\n" +
     "    <div\n" +
-    "      class=\"item__title\"\n" +
+    "      class=\"item__title item__title--single\"\n" +
     "      data-ng-bind=\"station.name\"></div>\n" +
     "  </div>\n" +
     "  <div class=\"item__actions\">\n" +

--- a/lstn/static/js/templates.js
+++ b/lstn/static/js/templates.js
@@ -381,10 +381,10 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
     "<div class=\"playing__info-container\">\n" +
     "\n" +
     "  <div data-ng-hide=\"playing\" class=\"playing__info--stopped\">\n" +
-    "    <a data-ng-show=\"queue.tracks.length\" href=\"\" data-ng-click=\"toggleBroadcast()\">\n" +
-    "      <i class=\"fa fa-play-circle\" />\n" +
+    "    <a data-ng-show=\"queue.tracks.length\" data-ng-click=\"toggleBroadcast()\">\n" +
+    "      <i class=\"playing__info--ready fa fa-play-circle\" />\n" +
     "    </a>\n" +
-    "    <p data-ng-show=\"!queue.tracks.length\">Waiting for a broadcaster&hellip;</p>\n" +
+    "    <p class=\"playing__info--waiting\" data-ng-show=\"!queue.tracks.length\">Waiting for a broadcaster&hellip;</p>\n" +
     "  </div>\n" +
     "\n" +
     "  <div data-ng-show=\"playing\" class=\"playing__info playing__info--playing\" data-album-cover-background>\n" +

--- a/lstn/static/partials/directives/category.html
+++ b/lstn/static/partials/directives/category.html
@@ -4,7 +4,7 @@
   </div>
   <div class="item__info">
     <div
-      class="item__title"
+      class="item__title item__title--single"
       data-ng-bind="category.name"></div>
   </div>
   <div class="item__actions">

--- a/lstn/static/partials/directives/category.html
+++ b/lstn/static/partials/directives/category.html
@@ -1,4 +1,4 @@
-<div id="category{{ $id }}" class="drilldown__item category clearfix">
+<div id="category{{ $id }}" class="drilldown__item category">
   <div class="item__image">
     <i class="fa fa-fw fa-music fa-3x"></i>
   </div>

--- a/lstn/static/partials/directives/drilldown-back.html
+++ b/lstn/static/partials/directives/drilldown-back.html
@@ -1,0 +1,17 @@
+<div class="carousel__back text-left">
+  <a data-ng-click="clickHandler()">
+    <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="text" data-tooltip="{{ tooltipText }}" data-tooltip-placement="right"></span>
+  </a>
+  <a class="carousel__refresh pull-right" data-ng-click="refreshHandler()" data-ng-show="refreshHandler">
+    <i
+      class="fa fa-fw fa-refresh"
+      data-ng-show="!loading"
+      data-tooltip="{{ refreshText }}"
+      data-tooltip-placement="left"></i>
+    <i
+      class="fa fa-fw fa-circle-o-notch fa-spin"
+      data-ng-show="loading"
+      data-tooltip="{{ loadingText }}"
+      data-tooltip-placement="left"></i>
+  </a>
+</div>

--- a/lstn/static/partials/directives/music-categories.html
+++ b/lstn/static/partials/directives/music-categories.html
@@ -26,11 +26,14 @@
     </slide>
 
     <slide id="playlists">
-      <div class="carousel__back text-left">
-        <a data-ng-click="closePlaylistType()">
-          <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentPlaylistType.name"></span>
-        </a>
-      </div>
+      <lstn-drilldown-back
+        data-text="currentPlaylistType.name"
+        data-tooltip-text="'Back to Categories'"
+        data-click-handler="closePlaylistType"
+        data-refresh-handler="refreshPlaylistType"
+        data-refresh-text="'Refresh Playlists'"
+        data-loading="currentPlaylistType.loadingPlaylists"
+        data-loading-text="'Refreshing Playlists'"></lstn-drilldown-back>
       <ul class="playlists drilldown__list text-left">
         <li data-ng-repeat="item in playlists">
           <lstn-playlist
@@ -43,11 +46,14 @@
     </slide>
 
     <slide id="playlist_tracks">
-      <div class="carousel__back text-left">
-        <a data-ng-click="closePlaylist()">
-          <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentPlaylist.name"></span>
-        </a>
-      </div>
+      <lstn-drilldown-back
+        data-text="currentPlaylist.name"
+        data-tooltip-text="'Back to Playlists'"
+        data-click-handler="closePlaylist"
+        data-refresh-handler="refreshPlaylist"
+        data-refresh-text="'Refresh Playlist'"
+        data-loading="currentPlaylist.loadingTracks"
+        data-loading-text="'Refreshing Playlist'"></lstn-drilldown-back>
       <ul class="tracks drilldown__list text-left">
         <li data-ng-repeat="item in tracks">
           <lstn-track
@@ -74,11 +80,14 @@
     </slide>
 
     <slide id="stations">
-      <div class="carousel__back text-left">
-        <a data-ng-click="closeStationType()">
-          <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentStationType.name"></span>
-        </a>
-      </div>
+      <lstn-drilldown-back
+        data-text="currentStationType.name"
+        data-tooltip-text="'Back to Categories'"
+        data-click-handler="closeStationType"
+        data-refresh-handler="refreshStationType"
+        data-refresh-text="'Refresh Stations'"
+        data-loading="currentStationType.loadingStations"
+        data-loading-text="'Refreshing Stations'"></lstn-drilldown-back>
       <ul class="stations drilldown__list text-left">
         <li data-ng-repeat="item in stations">
           <lstn-playlist
@@ -91,11 +100,14 @@
     </slide>
 
     <slide id="station_tracks">
-      <div class="carousel__back text-left">
-        <a data-ng-click="closeStation()">
-          <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentStation.name"></span>
-        </a>
-      </div>
+      <lstn-drilldown-back
+        data-text="currentStation.name"
+        data-tooltip-text="'Back to Stations'"
+        data-click-handler="closeStation"
+        data-refresh-handler="refreshStation"
+        data-refresh-text="'Refresh Station'"
+        data-loading="currentStation.loadingTracks"
+        data-loading-text="'Refreshing Station'"></lstn-drilldown-back>
       <ul class="tracks drilldown__list text-left">
         <li data-ng-repeat="item in tracks">
           <lstn-track

--- a/lstn/static/partials/directives/music-categories.html
+++ b/lstn/static/partials/directives/music-categories.html
@@ -11,11 +11,10 @@
     </slide>
 
     <slide id="playlist_types">
-      <div class="carousel__back text-left">
-        <a data-ng-click="closeCategory()">
-          <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentCategory.name"></span>
-        </a>
-      </div>
+      <lstn-drilldown-back
+        data-text="currentCategory.name"
+        data-tooltip-text="'Back to Categories'"
+        data-click-handler="closeCategory"></lstn-drilldown-back>
       <ul class="playlist-types playlist-types--full playlist-type__list drilldown__list text-left">
         <li data-ng-repeat="item in playlistTypes">
           <lstn-playlist-type
@@ -28,7 +27,7 @@
     <slide id="playlists">
       <lstn-drilldown-back
         data-text="currentPlaylistType.name"
-        data-tooltip-text="'Back to Categories'"
+        data-tooltip-text="'Back to Playlist Types'"
         data-click-handler="closePlaylistType"
         data-refresh-handler="refreshPlaylistType"
         data-refresh-text="'Refresh Playlists'"
@@ -65,11 +64,10 @@
     </slide>
 
     <slide id="station_types">
-      <div class="carousel__back text-left">
-        <a data-ng-click="closeCategory()">
-          <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentCategory.name"></span>
-        </a>
-      </div>
+      <lstn-drilldown-back
+        data-text="currentCategory.name"
+        data-tooltip-text="'Back to Categories'"
+        data-click-handler="closeCategory"></lstn-drilldown-back>
       <ul class="station-types station-types--full station-type__list drilldown__list text-left">
         <li data-ng-repeat="item in stationTypes">
           <lstn-station-type
@@ -82,7 +80,7 @@
     <slide id="stations">
       <lstn-drilldown-back
         data-text="currentStationType.name"
-        data-tooltip-text="'Back to Categories'"
+        data-tooltip-text="'Back to Station Types'"
         data-click-handler="closeStationType"
         data-refresh-handler="refreshStationType"
         data-refresh-text="'Refresh Stations'"

--- a/lstn/static/partials/directives/playing-info.html
+++ b/lstn/static/partials/directives/playing-info.html
@@ -1,10 +1,10 @@
 <div class="playing__info-container">
 
   <div data-ng-hide="playing" class="playing__info--stopped">
-    <a data-ng-show="queue.tracks.length" href="" data-ng-click="toggleBroadcast()">
-      <i class="fa fa-play-circle" />
+    <a data-ng-show="queue.tracks.length" data-ng-click="toggleBroadcast()">
+      <i class="playing__info--ready fa fa-play-circle" />
     </a>
-    <p data-ng-show="!queue.tracks.length">Waiting for a broadcaster&hellip;</p>
+    <p class="playing__info--waiting" data-ng-show="!queue.tracks.length">Waiting for a broadcaster&hellip;</p>
   </div>
 
   <div data-ng-show="playing" class="playing__info playing__info--playing" data-album-cover-background>

--- a/lstn/static/partials/directives/playlist-type.html
+++ b/lstn/static/partials/directives/playlist-type.html
@@ -1,4 +1,4 @@
-<div id="playlist-type{{ $id }}" class="drilldown__item playlist-type clearfix">
+<div id="playlist-type{{ $id }}" class="drilldown__item playlist-type">
   <div class="item__image">
     <i class="fa fa-fw fa-music fa-3x"></i>
   </div>

--- a/lstn/static/partials/directives/playlist-type.html
+++ b/lstn/static/partials/directives/playlist-type.html
@@ -4,7 +4,7 @@
   </div>
   <div class="item__info">
     <div
-      class="item__title"
+      class="item__title item__title--single"
       data-ng-bind="playlistType.name"></div>
   </div>
   <div class="item__actions">

--- a/lstn/static/partials/directives/playlist.html
+++ b/lstn/static/partials/directives/playlist.html
@@ -4,7 +4,7 @@
   </div>
   <div class="item__info">
     <div
-      class="item__title"
+      class="item__title item__title--couple"
       data-ng-bind="playlist.name"></div>
     <div class="item__count" data-ng-pluralize count="playlist.length" when="{'one': '{} track', 'other': '{} tracks'}"></div>
   </div>

--- a/lstn/static/partials/directives/room-roster.html
+++ b/lstn/static/partials/directives/room-roster.html
@@ -15,7 +15,7 @@
       <li class="roster__item--controller"
         data-ng-show="roster && roster.controllersCount > 0" data-ng-repeat="user_id in roster.controllerOrder">
         <a data-ng-href="http://www.rdio.com{{ roster.controllers[user_id].profile }}" target="_blank"
-          tooltip="{{ roster.controllers[user_id].name }}" data-tooltip-placement="bottom">
+          tooltip="{{ roster.controllers[user_id].name }} ({{ roster.controllers[user_id].points }})" data-tooltip-placement="bottom">
           <img data-ng-src="{{ roster.controllers[user_id].picture }}" class="avatar xs"
             data-ng-class="{upvoted: playing.upvotes[user_id], downvoted: playing.downvotes[user_id]}"
             alt="{{ roster.controllers[user_id].name }}" />
@@ -35,7 +35,7 @@
       <a class="roster__user"
         data-ng-href="http://www.rdio.com{{ user.profile }}"
         target="_blank"
-        tooltip="{{ user.name }}" data-tooltip-placement="bottom">
+        tooltip="{{ user.name }} ({{ user.points }})" data-tooltip-placement="bottom">
         <img data-ng-src="{{ user.picture }}"
         data-ng-class="{upvoted: playing.upvotes[user_id], downvoted: playing.downvotes[user_id]}"
         class="avatar xs" alt="{{ user.name }}" />

--- a/lstn/static/partials/directives/station-type.html
+++ b/lstn/static/partials/directives/station-type.html
@@ -4,7 +4,7 @@
   </div>
   <div class="item__info">
     <div
-      class="item__title"
+      class="item__title item__title--single"
       data-ng-bind="stationType.name"></div>
   </div>
   <div class="item__actions">

--- a/lstn/static/partials/directives/station.html
+++ b/lstn/static/partials/directives/station.html
@@ -4,7 +4,7 @@
   </div>
   <div class="item__info">
     <div
-      class="item__title"
+      class="item__title item__title--single"
       data-ng-bind="station.name"></div>
   </div>
   <div class="item__actions">

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -598,6 +598,14 @@ body {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+
+    &.item__title--single {
+      padding-top: 17px;
+    }
+
+    &.item__title--couple {
+      padding-top: 8px;
+    }
   }
 
   .item__artist {

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -93,7 +93,6 @@ body {
 
   > .container {
     height: 100%;
-    margin-bottom: 10px;
 
     > div {
       height: 80%;

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -126,7 +126,7 @@ body {
   font-size: 1.4em;
 
   .navbar-text {
-    margin-top: 0.95em;
+    margin-top: 1.05em;
   }
 
   .navbar-nav {
@@ -168,8 +168,8 @@ body {
   }
 
   .navbar__divider {
-    margin-left: 5px;
-    margin-right: 5px;
+    margin-left: -10px;
+    margin-right: -10px;
   }
 
   .navbar__room {

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -93,9 +93,10 @@ body {
 
   > .container {
     height: 100%;
+    margin-bottom: 10px;
 
     > div {
-      height: 85%;
+      height: 80%;
       margin-top: 15px;
     }
   }
@@ -132,24 +133,11 @@ body {
   .navbar-nav {
     &.navbar-right {
       margin: 0;
-    }
 
-    > li {
-      > a {
-        &.navbar__name {
-          color: #FFFFFF;
-          padding-left: 10px;
-        }
-      }
-    }
-
-    > .open {
-      > a {
-        background-color: $background-color;
-
-        &:focus, &:hover {
-          background-color: $background-color;
-        }
+      .divider {
+        line-height: 70px;
+        width: 1px;
+        border-left: 1px solid $background-color;
       }
     }
   }
@@ -428,7 +416,7 @@ body {
 }
 
 .queue__tabs {
-  height: 90%;
+  height: 100%;
   min-height: 400px;
   background-color: $accent-color;
 
@@ -468,7 +456,7 @@ body {
 }
 
 .tab-content {
-  height: 95%;
+  height: 100%;
 
   .tab-pane {
     height: 100%;
@@ -739,7 +727,7 @@ footer {
 }
 
 .room-activity {
-  height: 95%;
+  height: 100%;
   background-color: $accent-color;
 
   .form-control {
@@ -842,6 +830,15 @@ footer {
     text-transform: uppercase;
     text-decoration: none;
   }
+
+  .carousel__refresh {
+    padding-right: 15px;
+    color: white;
+
+    .fa {
+      font-size: 1.25em;
+    }
+  }
 }
 
 /* sm */
@@ -851,10 +848,6 @@ footer {
       padding-left: 15px;
       padding-right: 15px;
     }
-  }
-
-  div.queue__tabs {
-    height: 100%;
   }
 }
 

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -277,13 +277,12 @@ body {
 }
 
 .playing__info-container {
-  margin-bottom:36px;
+  margin-bottom: 36px;
 }
-.playing__info--stopped {
 
+.playing__info--stopped {
   background: #3d3d3d;
   min-height: 180px;
-  line-height: 180px;
   text-align: center;
   color: #fff;
   font-size: 1.7rem;
@@ -292,8 +291,18 @@ body {
     font-size: 8rem;
     line-height: 180px;
     color: $action-additive;
+    cursor: pointer;
   }
 }
+
+.playing__info--ready {
+  line-height: 180px;
+}
+
+.playing__info--waiting {
+  line-height: 180px;
+}
+
 .playing__info--playing {
   min-height:180px;
 }

--- a/lstn/templates/layout.html
+++ b/lstn/templates/layout.html
@@ -74,27 +74,17 @@
                 <a class="navbar-link" data-ng-href="/room/{{ currentRoom.slug }}" data-ng-bind="currentRoom.name"></a>
               </p>
             </li>
-            <li class="hidden-sm hidden-md hidden-lg">
+            <li class="divider">&nbsp;</li>
+            <li>
               <p class="navbar-text">
-                <a href="http://www.rdio.com%% current_user.profile %%" target="_blank">Profile</a>
+                <a href="http://www.rdio.com%% current_user.profile %%" target="_blank">%% current_user.name %%</a>
               </p>
             </li>
-            <li class="hidden-sm hidden-md hidden-lg">
+            <li class="divider">&nbsp;</li>
+            <li>
               <p class="navbar-text">
                 <a href="/logout" target="_self">Logout</a>
               </p>
-            </li>
-            <li class="dropdown hidden-xs">
-              <a class="navbar__name dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
-                <img data-ng-src="{{ current_user.picture }}" class="navbar__photo avatar xs ng-cloak" alt="{{ current_user.name }}">
-                %% current_user.name %%
-                <span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu" role="menu">
-                <li><a href="http://www.rdio.com%% current_user.profile %%" target="_blank">Profile</a></li>
-                <li class="divider"></li>
-                <li><a href="/logout" target="_self">Logout</a></li>
-              </ul>
             </li>
           </ul>
           <% else %>

--- a/lstn/templates/layout.html
+++ b/lstn/templates/layout.html
@@ -68,19 +68,19 @@
           <% if current_user.is_authenticated() %>
           <ul class="nav navbar-nav navbar-right">
             <li><p class="navbar__rooms navbar-text"><a class="navbar-link" href="/rooms">All Rooms</a></p></li>
-            <li data-ng-show="currentRoom.id" class="hidden-xs"><p class="navbar__divider navbar-text"><i class="fa fa-fw fa-angle-right"></i></p></li>
-            <li data-ng-show="currentRoom.id">
+            <li data-ng-show="currentRoom.id" class="hidden-xs ng-cloak"><p class="navbar__divider navbar-text"><i class="fa fa-fw fa-angle-right"></i></p></li>
+            <li data-ng-show="currentRoom.id" class="ng-cloak">
               <p class="navbar__room navbar-text">
                 <a class="navbar-link" data-ng-href="/room/{{ currentRoom.slug }}" data-ng-bind="currentRoom.name"></a>
               </p>
             </li>
-            <li class="divider">&nbsp;</li>
+            <li class="divider hidden-xs">&nbsp;</li>
             <li>
               <p class="navbar-text">
                 <a href="http://www.rdio.com%% current_user.profile %%" target="_blank">%% current_user.name %%</a>
               </p>
             </li>
-            <li class="divider">&nbsp;</li>
+            <li class="divider hidden-xs">&nbsp;</li>
             <li>
               <p class="navbar-text">
                 <a href="/logout" target="_self">Logout</a>


### PR DESCRIPTION
I tried a bubble similar to the broadcasting bubble but it seems really cluttered with the broadcasting bubble as well and it's not going to scale well to a larger number of points. I've added a tooltip instead. Fixes #153.

![screenshot 2015-02-25 07 48 47](https://cloud.githubusercontent.com/assets/196836/6370841/c42110fe-bcc2-11e4-9770-4e48310a097b.png)

I centered the drilldown item title text in the middle of the drilldown item when it was along or with another line. Fixes #134.

I killed the avatar in the header because it's caused my nothing but problems. I'll consider adding it again at a later date. I also cleaned up the spacing afterwards and added ng-cloak to the loading itmes to stop flicker. Fixes #139.

Added the ability to refresh the user's playlists, playlist tracks, stations, and station tracks. In the process, I also moved the back button for drilldown items into a directive.

I cleaned up the remaining jank in the scrolling columns. 

I fixed a small misalignment in the playing-info__stopped area.
