### PR TITLE
Fix the scrolling for search and more music

### DIFF
--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -457,6 +457,8 @@ body > .container > div {
   list-style: none;
   padding: 0;
   margin-bottom: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .drilldown__item, .chat__message {
@@ -763,6 +765,18 @@ footer .container .text-muted {
   margin-right: 4px;
 }
 
+.search__wrapper {
+  height: 100%;
+}
+
+.search__container {
+  height: 100%;
+}
+
+.search__contents {
+  height: 100%;
+}
+
 .search__box {
   border-bottom: 4px solid #3d3d3d;
 }
@@ -789,12 +803,15 @@ footer .container .text-muted {
   height: 100%;
 }
 .more-music .carousel-inner {
-  height: 93%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  height: 100%;
+  overflow: inherit;
 }
 .more-music .carousel-inner .item {
-  height: 100%;
+  height: 80%;
+}
+.more-music .carousel-inner .item .tracks {
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .carousel__back {

--- a/lstn/static/css/app.css
+++ b/lstn/static/css/app.css
@@ -453,6 +453,7 @@ body > .container > div {
 }
 
 .drilldown__list {
+  height: 100%;
   list-style: none;
   padding: 0;
   margin-bottom: 0;
@@ -775,11 +776,25 @@ footer .container .text-muted {
   border-color: #FFFFFF;
 }
 
+.more-music {
+  height: 100%;
+}
 .more-music .carousel-control {
   display: none;
 }
 .more-music .carousel-indicators {
   display: none;
+}
+.more-music .carousel {
+  height: 100%;
+}
+.more-music .carousel-inner {
+  height: 93%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.more-music .carousel-inner .item {
+  height: 100%;
 }
 
 .carousel__back {

--- a/lstn/static/js/templates.js
+++ b/lstn/static/js/templates.js
@@ -158,6 +158,9 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
 
   $templateCache.put('/static/partials/directives/more-music.html',
     "<div class=\"more-music\">\n" +
+    "  <div class=\"search__box\">\n" +
+    "    <input type=\"search\" class=\"form-control\" data-ng-model=\"searchQuery\" placeholder=\"Search music...\">\n" +
+    "  </div>\n" +
     "  <lstn-music-search></lstn-music-search>\n" +
     "  <lstn-music-categories data-ng-show=\"!searchResults || searchResults.length === 0\"></lstn-music-categories>\n" +
     "</div>\n"
@@ -288,80 +291,75 @@ angular.module('lstn.templates', []).run(['$templateCache', function($templateCa
 
 
   $templateCache.put('/static/partials/directives/music-search.html',
-    "<div>\n" +
-    "  <div class=\"search__box\">\n" +
-    "    <input type=\"search\" class=\"form-control\" data-ng-model=\"searchQuery\" placeholder=\"Search music...\">\n" +
-    "  </div>\n" +
-    "  <div class=\"search__container\" data-ng-show=\"searchResults && searchResults.length > 0\">\n" +
-    "    <div class=\"search__contents\">\n" +
-    "      <carousel id=\"search-carousel\" interval=\"false\">\n" +
-    "        <slide id=\"search_results\">\n" +
-    "          <div class=\"carousel__back text-left\">\n" +
-    "            <a data-ng-click=\"clearSearchResults()\">\n" +
-    "              <i class=\"fa fa-fw fa-times-circle-o\"></i> Clear Search Results\n" +
-    "            </a>\n" +
-    "          </div>\n" +
-    "          <ul class=\"search search--full track__list drilldown__list text-left\">\n" +
-    "            <li data-ng-repeat=\"item in searchResults\">\n" +
-    "              <div data-ng-switch=\"item.type\">\n" +
-    "                <lstn-album\n" +
-    "                  data-ng-switch-when=\"a\"\n" +
-    "                  data-context=\"'search'\"\n" +
-    "                  data-album=\"item\"\n" +
-    "                  data-index=\"$index\"\n" +
-    "                  data-load-album-tracks=\"loadAlbumTracks\"></lstn-album>\n" +
-    "\n" +
-    "                <lstn-artist\n" +
-    "                  data-ng-switch-when=\"r\"\n" +
-    "                  data-context=\"'search'\"\n" +
-    "                  data-artist=\"item\"\n" +
-    "                  data-index=\"$index\"\n" +
-    "                  data-load-albums=\"loadAlbums\"></lstn-artist>\n" +
-    "\n" +
-    "                <lstn-track\n" +
-    "                  data-ng-switch-when=\"t\"\n" +
-    "                  data-context=\"'search'\"\n" +
-    "                  data-track=\"item\"\n" +
-    "                  data-index=\"$index\"></lstn-track>\n" +
-    "              </div>\n" +
-    "            </li>\n" +
-    "          </ul>\n" +
-    "        </slide>\n" +
-    "\n" +
-    "        <slide id=\"search_albums\">\n" +
-    "          <div class=\"carousel__back text-left\">\n" +
-    "            <a data-ng-click=\"closeArtist()\">\n" +
-    "              <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentArtist.name\"></span>\n" +
-    "            </a>\n" +
-    "          </div>\n" +
-    "          <ul class=\"albums album--full album__list drilldown__list text-left\">\n" +
-    "            <li data-ng-repeat=\"item in albums\">\n" +
+    "<div class=\"search__container\" data-ng-show=\"searchResults && searchResults.length > 0\">\n" +
+    "  <div class=\"search__contents\">\n" +
+    "    <carousel id=\"search-carousel\" interval=\"false\">\n" +
+    "      <slide id=\"search_results\">\n" +
+    "        <div class=\"carousel__back text-left\">\n" +
+    "          <a data-ng-click=\"clearSearchResults()\">\n" +
+    "            <i class=\"fa fa-fw fa-times-circle-o\"></i> Clear Search Results\n" +
+    "          </a>\n" +
+    "        </div>\n" +
+    "        <ul class=\"search search--full track__list drilldown__list text-left\">\n" +
+    "          <li data-ng-repeat=\"item in searchResults\">\n" +
+    "            <div data-ng-switch=\"item.type\">\n" +
     "              <lstn-album\n" +
-    "                data-context=\"'artist'\"\n" +
+    "                data-ng-switch-when=\"a\"\n" +
+    "                data-context=\"'search'\"\n" +
     "                data-album=\"item\"\n" +
     "                data-index=\"$index\"\n" +
     "                data-load-album-tracks=\"loadAlbumTracks\"></lstn-album>\n" +
-    "            </li>\n" +
-    "          </ul>\n" +
-    "        </slide>\n" +
     "\n" +
-    "        <slide id=\"search_tracks\">\n" +
-    "          <div class=\"carousel__back text-left\">\n" +
-    "            <a data-ng-click=\"closeAlbum()\">\n" +
-    "              <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentAlbum.name\"></span>\n" +
-    "            </a>\n" +
-    "          </div>\n" +
-    "          <ul class=\"tracks track--full track__list drilldown__list text-left\">\n" +
-    "            <li data-ng-repeat=\"item in tracks\">\n" +
+    "              <lstn-artist\n" +
+    "                data-ng-switch-when=\"r\"\n" +
+    "                data-context=\"'search'\"\n" +
+    "                data-artist=\"item\"\n" +
+    "                data-index=\"$index\"\n" +
+    "                data-load-albums=\"loadAlbums\"></lstn-artist>\n" +
+    "\n" +
     "              <lstn-track\n" +
-    "                data-context=\"'album'\"\n" +
+    "                data-ng-switch-when=\"t\"\n" +
+    "                data-context=\"'search'\"\n" +
     "                data-track=\"item\"\n" +
     "                data-index=\"$index\"></lstn-track>\n" +
-    "            </li>\n" +
-    "          </ul>\n" +
-    "        </slide>\n" +
-    "      </carousel>\n" +
-    "    </div>\n" +
+    "            </div>\n" +
+    "          </li>\n" +
+    "        </ul>\n" +
+    "      </slide>\n" +
+    "\n" +
+    "      <slide id=\"search_albums\">\n" +
+    "        <div class=\"carousel__back text-left\">\n" +
+    "          <a data-ng-click=\"closeArtist()\">\n" +
+    "            <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentArtist.name\"></span>\n" +
+    "          </a>\n" +
+    "        </div>\n" +
+    "        <ul class=\"albums album--full album__list drilldown__list text-left\">\n" +
+    "          <li data-ng-repeat=\"item in albums\">\n" +
+    "            <lstn-album\n" +
+    "              data-context=\"'artist'\"\n" +
+    "              data-album=\"item\"\n" +
+    "              data-index=\"$index\"\n" +
+    "              data-load-album-tracks=\"loadAlbumTracks\"></lstn-album>\n" +
+    "          </li>\n" +
+    "        </ul>\n" +
+    "      </slide>\n" +
+    "\n" +
+    "      <slide id=\"search_tracks\">\n" +
+    "        <div class=\"carousel__back text-left\">\n" +
+    "          <a data-ng-click=\"closeAlbum()\">\n" +
+    "            <i class=\"fa fa-fw fa-chevron-left\"></i><span data-ng-bind=\"currentAlbum.name\"></span>\n" +
+    "          </a>\n" +
+    "        </div>\n" +
+    "        <ul class=\"tracks track--full track__list drilldown__list text-left\">\n" +
+    "          <li data-ng-repeat=\"item in tracks\">\n" +
+    "            <lstn-track\n" +
+    "              data-context=\"'album'\"\n" +
+    "              data-track=\"item\"\n" +
+    "              data-index=\"$index\"></lstn-track>\n" +
+    "          </li>\n" +
+    "        </ul>\n" +
+    "      </slide>\n" +
+    "    </carousel>\n" +
     "  </div>\n" +
     "</div>\n"
   );

--- a/lstn/static/partials/directives/more-music.html
+++ b/lstn/static/partials/directives/more-music.html
@@ -1,4 +1,7 @@
 <div class="more-music">
+  <div class="search__box">
+    <input type="search" class="form-control" data-ng-model="searchQuery" placeholder="Search music...">
+  </div>
   <lstn-music-search></lstn-music-search>
   <lstn-music-categories data-ng-show="!searchResults || searchResults.length === 0"></lstn-music-categories>
 </div>

--- a/lstn/static/partials/directives/music-search.html
+++ b/lstn/static/partials/directives/music-search.html
@@ -1,76 +1,71 @@
-<div>
-  <div class="search__box">
-    <input type="search" class="form-control" data-ng-model="searchQuery" placeholder="Search music...">
-  </div>
-  <div class="search__container" data-ng-show="searchResults && searchResults.length > 0">
-    <div class="search__contents">
-      <carousel id="search-carousel" interval="false">
-        <slide id="search_results">
-          <div class="carousel__back text-left">
-            <a data-ng-click="clearSearchResults()">
-              <i class="fa fa-fw fa-times-circle-o"></i> Clear Search Results
-            </a>
-          </div>
-          <ul class="search search--full track__list drilldown__list text-left">
-            <li data-ng-repeat="item in searchResults">
-              <div data-ng-switch="item.type">
-                <lstn-album
-                  data-ng-switch-when="a"
-                  data-context="'search'"
-                  data-album="item"
-                  data-index="$index"
-                  data-load-album-tracks="loadAlbumTracks"></lstn-album>
-
-                <lstn-artist
-                  data-ng-switch-when="r"
-                  data-context="'search'"
-                  data-artist="item"
-                  data-index="$index"
-                  data-load-albums="loadAlbums"></lstn-artist>
-
-                <lstn-track
-                  data-ng-switch-when="t"
-                  data-context="'search'"
-                  data-track="item"
-                  data-index="$index"></lstn-track>
-              </div>
-            </li>
-          </ul>
-        </slide>
-
-        <slide id="search_albums">
-          <div class="carousel__back text-left">
-            <a data-ng-click="closeArtist()">
-              <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentArtist.name"></span>
-            </a>
-          </div>
-          <ul class="albums album--full album__list drilldown__list text-left">
-            <li data-ng-repeat="item in albums">
+<div class="search__container" data-ng-show="searchResults && searchResults.length > 0">
+  <div class="search__contents">
+    <carousel id="search-carousel" interval="false">
+      <slide id="search_results">
+        <div class="carousel__back text-left">
+          <a data-ng-click="clearSearchResults()">
+            <i class="fa fa-fw fa-times-circle-o"></i> Clear Search Results
+          </a>
+        </div>
+        <ul class="search search--full track__list drilldown__list text-left">
+          <li data-ng-repeat="item in searchResults">
+            <div data-ng-switch="item.type">
               <lstn-album
-                data-context="'artist'"
+                data-ng-switch-when="a"
+                data-context="'search'"
                 data-album="item"
                 data-index="$index"
                 data-load-album-tracks="loadAlbumTracks"></lstn-album>
-            </li>
-          </ul>
-        </slide>
 
-        <slide id="search_tracks">
-          <div class="carousel__back text-left">
-            <a data-ng-click="closeAlbum()">
-              <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentAlbum.name"></span>
-            </a>
-          </div>
-          <ul class="tracks track--full track__list drilldown__list text-left">
-            <li data-ng-repeat="item in tracks">
+              <lstn-artist
+                data-ng-switch-when="r"
+                data-context="'search'"
+                data-artist="item"
+                data-index="$index"
+                data-load-albums="loadAlbums"></lstn-artist>
+
               <lstn-track
-                data-context="'album'"
+                data-ng-switch-when="t"
+                data-context="'search'"
                 data-track="item"
                 data-index="$index"></lstn-track>
-            </li>
-          </ul>
-        </slide>
-      </carousel>
-    </div>
+            </div>
+          </li>
+        </ul>
+      </slide>
+
+      <slide id="search_albums">
+        <div class="carousel__back text-left">
+          <a data-ng-click="closeArtist()">
+            <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentArtist.name"></span>
+          </a>
+        </div>
+        <ul class="albums album--full album__list drilldown__list text-left">
+          <li data-ng-repeat="item in albums">
+            <lstn-album
+              data-context="'artist'"
+              data-album="item"
+              data-index="$index"
+              data-load-album-tracks="loadAlbumTracks"></lstn-album>
+          </li>
+        </ul>
+      </slide>
+
+      <slide id="search_tracks">
+        <div class="carousel__back text-left">
+          <a data-ng-click="closeAlbum()">
+            <i class="fa fa-fw fa-chevron-left"></i><span data-ng-bind="currentAlbum.name"></span>
+          </a>
+        </div>
+        <ul class="tracks track--full track__list drilldown__list text-left">
+          <li data-ng-repeat="item in tracks">
+            <lstn-track
+              data-context="'album'"
+              data-track="item"
+              data-index="$index"></lstn-track>
+          </li>
+        </ul>
+      </slide>
+    </carousel>
   </div>
 </div>

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -516,6 +516,8 @@ body {
 }
 
 .drilldown__list {
+  height: 100%;
+
   list-style: none;
   padding: 0;
   margin-bottom: 0;
@@ -821,12 +823,28 @@ footer {
 }
 
 .more-music {
+  height: 100%;
+
   .carousel-control {
     display: none;
   }
 
   .carousel-indicators {
     display: none;
+  }
+
+  .carousel {
+    height: 100%;
+  }
+
+  .carousel-inner {
+    height: 93%;
+    overflow-x: hidden;
+    overflow-y: auto;
+
+    .item {
+      height: 100%;
+    }
   }
 }
 

--- a/lstn/static/sass/app.scss
+++ b/lstn/static/sass/app.scss
@@ -521,6 +521,8 @@ body {
   list-style: none;
   padding: 0;
   margin-bottom: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .drilldown__item, .chat__message {
@@ -812,6 +814,18 @@ footer {
   margin-right: 4px;
 }
 
+.search__wrapper {
+  height: 100%;
+}
+
+.search__container {
+  height: 100%;
+}
+
+.search__contents {
+  height: 100%;
+}
+
 .search__box {
   border-bottom: 4px solid $accent-color;
 
@@ -838,12 +852,16 @@ footer {
   }
 
   .carousel-inner {
-    height: 93%;
-    overflow-x: hidden;
-    overflow-y: auto;
+    height: 100%;
+    overflow: inherit;
 
     .item {
-      height: 100%;
+      height: 80%;
+
+      .tracks {
+        overflow-x: hidden;
+        overflow-y: auto;
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes the scrolling overflow issues for search and more music.

On another note: This scrolling stuff is quickly becoming a jungle and caveats abound. There' s definitely a height difference between columns.

My next steps will probably be to build out a simpler DOM tree that I can perfect as far as scrolling goes and then try getting elements into it without breaking scrolling. I might also try the ```bottom: 0``` trick that Michael mentioned. I think some of the built-in Bootstrap classes may be making this much more difficult and I also think the carousels are doing something weird. I might try to rip those out for a custom solution using the same transformations and JS but without the carousel styling overhead.

Long term, I don't think we necessarily need Bootstrap anymore as we've built out the UI ourselves and in many cases had to compensate for built-in Bootstrap styling. I'll probably look at killing Bootstrap in the future after we launch and moving towards something like Bourbon (bourbon.io) with Neat, Bitters, and Refills.